### PR TITLE
Several new types and bug fixes

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -187,4 +187,19 @@ func TestLineComplexity(t *testing.T) {
 	LC = tf.NamedFunction(t, "Send", fn)
 	LC(`done <- true`).Returns(0)
 	LC(`done <- foo(bar(baz))`).Returns(2)
+
+	LC = tf.NamedFunction(t, "Label", fn)
+	LC(`foo:`).Returns(0)
+
+	LC = tf.NamedFunction(t, "Select", fn)
+	LC(`select {}`).Returns(0)
+
+	LC = tf.NamedFunction(t, "Struct", fn)
+	LC(`new(struct{})`).Returns(1)
+
+	LC = tf.NamedFunction(t, "Interface", fn)
+	LC(`new(interface{})`).Returns(1)
+
+	LC = tf.NamedFunction(t, "Block", fn)
+	LC(`{ a := 123 }`).Returns(0)
 }


### PR DESCRIPTION
- Fixed by where non-Go (external) functions caused a panic.
- Better handling of panics caused by expressions so that the original line context is always printed.
- Added new types for ast.LabeledStmt, ast.SelectStmt, ast.BlockStmt, ast.StructType and ast.InterfaceType.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ghost/7)
<!-- Reviewable:end -->
