### PR TITLE
ast.SelectorExpr must be zero complexity

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,7 +189,25 @@ func exprComplexity(expr ast.Expr) int {
 	*ast.ChanType:
 		return 0
 
-	case *ast.UnaryExpr, *ast.TypeAssertExpr, *ast.SelectorExpr:
+	case *ast.SelectorExpr:
+		// SelectorExpr is accessing a variable on a struct, like "foo.bar". A
+		// SelectorExpr must be considered zero complexity for a few reasons:
+		//
+		// 1. To say "foo.bar" you must already have "foo" as a variable to
+		// inspect. So "bar" is viewable by the debugger without any
+		// intermediate step.
+		//
+		// 2. If we consider "foo.bar" to be of complexity 1 then function calls
+		// like "foo(bar.baz, bar.qux)" will increase in complexity with each
+		// argument. For the previous reason there is no need or benefit to
+		// assigning each of the arguments into an intermediate variable to
+		// decrease complexity.
+		//
+		// 3. The two previous rules also hold true when chaining multiple
+		// selectors together like "foo.bar.baz".
+		return 0
+
+	case *ast.UnaryExpr, *ast.TypeAssertExpr:
 		return 1
 
 	case *ast.StarExpr:

--- a/main_test.go
+++ b/main_test.go
@@ -48,6 +48,7 @@ func TestLineComplexity(t *testing.T) {
 	LC(`foo(1 + 2, "foo")`).Returns(2)
 	LC(`foo(1 + name, "foo")`).Returns(2)
 	LC(`foo(1 + name, "foo" + name)`).Returns(3)
+	LC(`foo(a.b, a.c, a.d, a.e)`).Returns(1)
 
 	LC = tf.NamedFunction(t, "CompositeLiteral", fn)
 	LC(`words := []string{}`).Returns(1)
@@ -89,8 +90,8 @@ func TestLineComplexity(t *testing.T) {
 	LC(`if a || b {}`).Returns(1)
 
 	LC = tf.NamedFunction(t, "Selector", fn)
-	LC(`a.b`).Returns(1)
-	LC(`a.b.c`).Returns(1)
+	LC(`a.b`).Returns(0)
+	LC(`a.b.c`).Returns(0)
 
 	LC = tf.NamedFunction(t, "Declaration", fn)
 	LC(`var a float64`).Returns(0)
@@ -107,7 +108,7 @@ func TestLineComplexity(t *testing.T) {
 
 	LC = tf.NamedFunction(t, "Range", fn)
 	LC(`for range foo {}`).Returns(0)
-	LC(`for range foo.bar {}`).Returns(1)
+	LC(`for range foo.bar {}`).Returns(0)
 	LC(`for range foo("bar") {}`).Returns(1)
 	LC(`for range foo(bar()) {}`).Returns(2)
 


### PR DESCRIPTION
Reducing an ast.SelectorExpr complexity from 1 to 0.

SelectorExpr is accessing a variable on a struct, like "foo.bar". A SelectorExpr must be considered zero complexity for a few reasons:

1. To say "foo.bar" you must already have "foo" as a variable to inspect. So "bar" is viewable by the debugger without any intermediate step.

2. If we consider "foo.bar" to be of complexity 1 then function calls like "foo(bar.baz, bar.qux)" will increase in complexity with each argument. For the previous reason there is no need or benefit to assigning each of the arguments into an intermediate variable to decrease complexity.

3. The two previous rules also hold true when chaining multiple selectors together like "foo.bar.baz".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ghost/8)
<!-- Reviewable:end -->
