### PR TITLE
Catch "&&" nil short-circuit

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -67,6 +67,8 @@ func TestLineComplexity(t *testing.T) {
 	LC(`foo(bar) || baz`).Returns(2)
 	LC(`true || foo(bar)`).Returns(2)
 	LC(`foo(bar) || foo(bar)`).Returns(3)
+	LC(`c.a != nil && c.a.Foo()`).Returns(1)
+	LC(`c.a != nil || c.a.Foo()`).Returns(3)
 
 	LC = tf.NamedFunction(t, "Return", fn)
 	LC(`return`).Returns(0)


### PR DESCRIPTION
The logical AND operator ("&&") is a special case when the left side is an equality test against nil. Since it is very common to use && to short-circuit a nil access like "c.a != nil && c.a.Foo()" we effectively ignore the complexity on the left side.

This is because there is no reasonable way to reduce this kind of expression without just making the code more verbose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ghost/9)
<!-- Reviewable:end -->
