### PR TITLE
Improve "for" complexity

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -146,8 +146,10 @@ func TestLineComplexity(t *testing.T) {
 
 	LC = tf.NamedFunction(t, "For", fn)
 	LC(`for {}`).Returns(0)
-	LC(`for true {}`).Returns(1)
-	LC(`for true && false {}`).Returns(2)
+	LC(`for true {}`).Returns(0)
+	LC(`for true && false {}`).Returns(1)
+	LC(`for i := 0; i <= foo(bar()); i++ {}`).Returns(3)
+	LC(`for i := rune('a'); i <= rune('z'); i++ {}`).Returns(2)
 
 	LC = tf.NamedFunction(t, "TypeAssert", fn)
 	LC(`a.(Foo)`).Returns(1)


### PR DESCRIPTION
A "for" statement can contain multiple components. Previously only the Cond was checked. We have to consider the complexity of each element and only return the maximum complexity.

The condition complexity does not have +1 added to it like you would expect because it is expected that a binary expression containing the iterator is included in the expression and this can not be further simplified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ghost/13)
<!-- Reviewable:end -->
