### PR TITLE
Panic with nil consumeComment

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,6 +76,10 @@ func checkFunction(fn *ast.FuncDecl) {
 }
 
 func consumeComment(line ast.Stmt) (comment string) {
+	if isNil(line) {
+		return
+	}
+
 	for commentGroupIndex < len(file.Comments) {
 		commentGroup := file.Comments[commentGroupIndex]
 		if commentGroup.Pos() < line.Pos() {
@@ -377,4 +381,13 @@ func maxInt(numbers ...int) int {
 	sort.Ints(numbers)
 
 	return numbers[len(numbers)-1]
+}
+
+func isNil(x interface{}) bool {
+	switch x.(type) {
+	case nil:
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
This fixes a bug that causes a nil statement passed into consumeComment causes a panic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/ghost/14)
<!-- Reviewable:end -->
