### PR TITLE
"&" unary operator is 0 complexity

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -86,7 +86,7 @@ func TestLineComplexity(t *testing.T) {
 
 	LC = tf.NamedFunction(t, "Unary", fn)
 	LC(`!foo`).Returns(1)
-	LC(`&foo`).Returns(1)
+	LC(`&foo`).Returns(0)
 	LC(`!!foo`).Returns(1)
 
 	LC = tf.NamedFunction(t, "If", fn)


### PR DESCRIPTION
The "&" operator must be zero because the returned value isn't really useful to inspect and it's very common to pass a variable by reference as a function argument which would increase the overall complexity.